### PR TITLE
Edit #menu-bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
             <img src="src/bravo_logo.png" alt="logo">
         </div>
         <div id="menu-bar" class="box">
-            <label for="about">About</label>
-            <label for="contact">Let's Talk</label>
+            <a href="about.html" id="about">ABOUT</a> <!--changed tags from label to a-->
+            <a href="contact.html" id="contact">LET'S TALK</a> <!--changed tags from label to a-->
         </div>
     </div>
     <!-- with reference https://codeburst.io/css-grid-vs-flexbox-building-simple-layouts-43e569a66f0a -->

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -7,7 +7,16 @@
     width: 100%;
 }
 #menu-bar{
-    position: relative;
+    position: absolute; /*using absolute and right to keep it in the upper right corner*/
+    right: 20px;
+    padding: 0px;
+}
+
+#menu-bar a{
+    /*to get plain black texts for about and contact links*/
+    text-decoration: none;
+    color: black;
+    margin: 0px 20px;
 }
 #side-banner img{
     height: 100%;


### PR DESCRIPTION
-Changed tags for about and contact from label to a, and href to respective pages
-Changed #menu-bar position from relative to absolute + right to keep it on the upper right corner of page.
-Added style for #menu-bar to get plain back texts for about and contact links.